### PR TITLE
refactor: commander returning results

### DIFF
--- a/disma/src/api/apply_changes.rs
+++ b/disma/src/api/apply_changes.rs
@@ -208,31 +208,29 @@ mod tests {
     }
 
     fn prepare_commander_for_roles(commander: &GuildCommanderMock) {
-        commander.when_add_role(any()).will_return_default();
-        commander
-            .when_update_role(any(), any())
-            .will_return_default();
-        commander.when_delete_role(any()).will_return_default();
+        commander.when_add_role(any()).will_return(Ok(()));
+        commander.when_update_role(any(), any()).will_return(Ok(()));
+        commander.when_delete_role(any()).will_return(Ok(()));
     }
 
     fn prepare_commander_for_categories(commander: &GuildCommanderMock) {
         commander
             .when_add_category(any(), any())
-            .will_return_default();
+            .will_return(Ok(()));
         commander
             .when_update_category(any(), any(), any())
-            .will_return_default();
-        commander.when_delete_category(any()).will_return_default();
+            .will_return(Ok(()));
+        commander.when_delete_category(any()).will_return(Ok(()));
     }
 
     fn prepare_commander_for_channels(commander: &GuildCommanderMock) {
         commander
             .when_add_channel(any(), any(), any())
-            .will_return_default();
+            .will_return(Ok(()));
         commander
             .when_update_channel(any(), any(), any(), any())
-            .will_return_default();
-        commander.when_delete_channel(any()).will_return_default();
+            .will_return(Ok(()));
+        commander.when_delete_channel(any()).will_return(Ok(()));
     }
 
     #[test]

--- a/disma/src/application/changes.rs
+++ b/disma/src/application/changes.rs
@@ -324,13 +324,13 @@ mod tests {
         };
         guild_commander
             .when_add_role(eq(&created_role.into()))
-            .will_return_default();
+            .will_return(Ok(()));
         guild_commander
             .when_update_role(eq(&role_to_update.id), eq(&updated_role.into()))
-            .will_return_default();
+            .will_return(Ok(()));
         guild_commander
             .when_delete_role(eq(&role_to_delete.id))
-            .will_return_default();
+            .will_return(Ok(()));
 
         let service = ChangesService::new(
             guild_commander,

--- a/disma/src/domain/category/commands.rs
+++ b/disma/src/domain/category/commands.rs
@@ -60,7 +60,7 @@ impl AddCategory {
 
 impl Command for AddCategory {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.add_category(&self.category, &self.roles);
+        guild.add_category(&self.category, &self.roles).unwrap();
     }
 
     fn describe(&self) -> CommandDescription {
@@ -101,11 +101,13 @@ impl UpdateCategory {
 
 impl Command for UpdateCategory {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.update_category(
-            &self.existing_category.id,
-            &self.awaiting_category,
-            &self.roles,
-        );
+        guild
+            .update_category(
+                &self.existing_category.id,
+                &self.awaiting_category,
+                &self.roles,
+            )
+            .unwrap();
     }
 
     fn describe(&self) -> CommandDescription {
@@ -129,7 +131,7 @@ impl DeleteCategory {
 
 impl Command for DeleteCategory {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.delete_category(&self.category.id);
+        guild.delete_category(&self.category.id).unwrap();
     }
 
     fn describe(&self) -> CommandDescription {

--- a/disma/src/domain/channel/commands.rs
+++ b/disma/src/domain/channel/commands.rs
@@ -89,7 +89,9 @@ impl AddChannel {
 
 impl Command for AddChannel {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.add_channel(&self.channel, &self.roles, &self.categories);
+        guild
+            .add_channel(&self.channel, &self.roles, &self.categories)
+            .unwrap();
     }
 
     fn describe(&self) -> CommandDescription {
@@ -136,12 +138,14 @@ impl UpdateChannel {
 
 impl Command for UpdateChannel {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.update_channel(
-            &self.existing_channel.id,
-            &self.awaiting_channel,
-            &self.roles,
-            &self.categories,
-        );
+        guild
+            .update_channel(
+                &self.existing_channel.id,
+                &self.awaiting_channel,
+                &self.roles,
+                &self.categories,
+            )
+            .unwrap();
     }
 
     fn describe(&self) -> CommandDescription {
@@ -165,7 +169,7 @@ impl DeleteChannel {
 
 impl Command for DeleteChannel {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.delete_category(&self.channel.id);
+        guild.delete_category(&self.channel.id).unwrap();
     }
 
     fn describe(&self) -> CommandDescription {

--- a/disma/src/domain/guild.rs
+++ b/disma/src/domain/guild.rs
@@ -15,31 +15,35 @@ pub type GuildQuerierRef = Arc<dyn GuildQuerier>;
 
 #[cfg_attr(test, mock_it::mock_it)]
 pub trait GuildCommander {
-    fn add_role(&self, role: &AwaitingRole);
-    fn update_role(&self, id: &str, role: &AwaitingRole);
-    fn delete_role(&self, id: &str);
-    fn add_category(&self, category: &AwaitingCategory, roles: &RolesList<ExistingRole>);
+    fn add_role(&self, role: &AwaitingRole) -> Result<(), String>;
+    fn update_role(&self, id: &str, role: &AwaitingRole) -> Result<(), String>;
+    fn delete_role(&self, id: &str) -> Result<(), String>;
+    fn add_category(
+        &self,
+        category: &AwaitingCategory,
+        roles: &RolesList<ExistingRole>,
+    ) -> Result<(), String>;
     fn update_category(
         &self,
         id: &str,
         category: &AwaitingCategory,
         roles: &RolesList<ExistingRole>,
-    );
-    fn delete_category(&self, id: &str);
+    ) -> Result<(), String>;
+    fn delete_category(&self, id: &str) -> Result<(), String>;
     fn add_channel(
         &self,
         channel: &AwaitingChannel,
         roles: &RolesList<ExistingRole>,
         categories: &CategoriesList<ExistingCategory>,
-    );
+    ) -> Result<(), String>;
     fn update_channel(
         &self,
         id: &str,
         channel: &AwaitingChannel,
         roles: &RolesList<ExistingRole>,
         categories: &CategoriesList<ExistingCategory>,
-    );
-    fn delete_channel(&self, id: &str);
+    ) -> Result<(), String>;
+    fn delete_channel(&self, id: &str) -> Result<(), String>;
 }
 pub type GuildCommanderRef = Arc<dyn GuildCommander>;
 

--- a/disma/src/domain/role/commands.rs
+++ b/disma/src/domain/role/commands.rs
@@ -54,7 +54,7 @@ impl AddRole {
 
 impl Command for AddRole {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.add_role(&self.role);
+        guild.add_role(&self.role).unwrap();
     }
 
     fn describe(&self) -> CommandDescription {
@@ -92,7 +92,9 @@ impl UpdateRole {
 
 impl Command for UpdateRole {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.update_role(&self.existing_role.id, &self.awaiting_role);
+        guild
+            .update_role(&self.existing_role.id, &self.awaiting_role)
+            .unwrap();
     }
 
     fn describe(&self) -> CommandDescription {
@@ -116,7 +118,7 @@ impl DeleteRole {
 
 impl Command for DeleteRole {
     fn execute(&self, guild: &GuildCommanderRef) {
-        guild.delete_role(&self.role.id);
+        guild.delete_role(&self.role.id).unwrap();
     }
 
     fn describe(&self) -> CommandDescription {

--- a/disma/src/impls/discord/http_commander.rs
+++ b/disma/src/impls/discord/http_commander.rs
@@ -27,29 +27,38 @@ impl HttpGuildCommander {
 }
 
 impl GuildCommander for HttpGuildCommander {
-    fn add_role(&self, role: &AwaitingRole) {
+    fn add_role(&self, role: &AwaitingRole) -> Result<(), String> {
         self.api
             .add_role(&self.guild_id, RoleRequest::from(role))
-            .unwrap();
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
-    fn update_role(&self, id: &str, role: &AwaitingRole) {
+    fn update_role(&self, id: &str, role: &AwaitingRole) -> Result<(), String> {
         self.api
             .update_role(&self.guild_id, id, RoleRequest::from(role))
-            .unwrap();
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
-    fn delete_role(&self, id: &str) {
-        self.api.delete_role(&self.guild_id, id).unwrap();
+    fn delete_role(&self, id: &str) -> Result<(), String> {
+        self.api
+            .delete_role(&self.guild_id, id)
+            .map_err(|error| error.to_string())
     }
 
-    fn add_category(&self, category: &AwaitingCategory, roles: &RolesList<ExistingRole>) {
+    fn add_category(
+        &self,
+        category: &AwaitingCategory,
+        roles: &RolesList<ExistingRole>,
+    ) -> Result<(), String> {
         self.api
             .add_channel(
                 &self.guild_id,
                 ChannelRequest::from_category(category, roles),
             )
-            .unwrap();
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
     fn update_category(
@@ -57,14 +66,17 @@ impl GuildCommander for HttpGuildCommander {
         id: &str,
         category: &AwaitingCategory,
         roles: &RolesList<ExistingRole>,
-    ) {
+    ) -> Result<(), String> {
         self.api
             .update_channel(id, ChannelRequest::from_category(category, roles))
-            .unwrap();
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
-    fn delete_category(&self, id: &str) {
-        self.api.delete_channel(id).unwrap();
+    fn delete_category(&self, id: &str) -> Result<(), String> {
+        self.api
+            .delete_channel(id)
+            .map_err(|error| error.to_string())
     }
 
     fn add_channel(
@@ -72,13 +84,14 @@ impl GuildCommander for HttpGuildCommander {
         channel: &AwaitingChannel,
         roles: &RolesList<ExistingRole>,
         categories: &CategoriesList<ExistingCategory>,
-    ) {
+    ) -> Result<(), String> {
         self.api
             .add_channel(
                 &self.guild_id,
                 ChannelRequest::from_channel(channel, roles, categories),
             )
-            .unwrap();
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
     fn update_channel(
@@ -87,13 +100,17 @@ impl GuildCommander for HttpGuildCommander {
         channel: &AwaitingChannel,
         roles: &RolesList<ExistingRole>,
         categories: &CategoriesList<ExistingCategory>,
-    ) {
+    ) -> Result<(), String> {
         self.api
             .update_channel(id, ChannelRequest::from_channel(channel, roles, categories))
-            .unwrap();
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
-    fn delete_channel(&self, id: &str) {
-        self.api.delete_channel(id).unwrap();
+    fn delete_channel(&self, id: &str) -> Result<(), String> {
+        self.api
+            .delete_channel(id)
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 }


### PR DESCRIPTION
Closes #80 

Now returns basic results (empty with string errors). Should return enum errors and existing entities in the future.