### PR TITLE
refactor: updating existing guild in commands

### DIFF
--- a/disma-cli/examples/bug.yaml
+++ b/disma-cli/examples/bug.yaml
@@ -13,9 +13,12 @@ roles:
 categories:
   items:
     - name: First
+    - name: Second
 
 channels:
   items:
+    - name: same_name
     - category: First
       name: same_name
-    - name: same_name
+    - category: Second
+      name: same_name

--- a/disma-cli/examples/bug.yaml
+++ b/disma-cli/examples/bug.yaml
@@ -1,0 +1,21 @@
+roles:
+  items:
+    - name: "@everyone"
+      permissions: []
+      show_in_sidebar: false
+      is_mentionable: false
+    - name: disma
+      permissions:
+        - ADMINISTRATOR
+      show_in_sidebar: false
+      is_mentionable: false
+
+categories:
+  items:
+    - name: First
+
+channels:
+  items:
+    - category: First
+      name: same_name
+    - name: same_name

--- a/disma-cli/examples/empty.yaml
+++ b/disma-cli/examples/empty.yaml
@@ -13,22 +13,9 @@ roles:
     strategy: REMOVE
 
 categories:
-  items:
-    - name: Category
-      permissions_overwrites:
-        - role: "@everyone"
-          allow:
-            - MANAGE_CHANNELS
-      extra_channels:
-        strategy: SYNC_PERMISSIONS
   extra_items:
     strategy: REMOVE
 
 channels:
-  items:
-    - category: Category
-      name: text
-      permissions_overwrites:
-        strategy: FROM_CATEGORY
   extra_items:
     strategy: REMOVE

--- a/disma-cli/examples/minimal.yaml
+++ b/disma-cli/examples/minimal.yaml
@@ -9,13 +9,3 @@ roles:
         - ADMINISTRATOR
       show_in_sidebar: false
       is_mentionable: false
-  extra_items:
-    strategy: REMOVE
-
-categories:
-  extra_items:
-    strategy: REMOVE
-
-channels:
-  extra_items:
-    strategy: REMOVE

--- a/disma-cli/examples/simple.yaml
+++ b/disma-cli/examples/simple.yaml
@@ -1,0 +1,76 @@
+roles:
+  items:
+    - name: "@everyone"
+      permissions:
+        - READ_MESSAGE_HISTORY
+      show_in_sidebar: false
+      is_mentionable: false
+    - name: disma
+      permissions:
+        - ADMINISTRATOR
+      show_in_sidebar: false
+      is_mentionable: false
+    - name: Basic
+      permissions:
+        - CONNECT
+        - SPEAK
+        - READ_MESSAGE_HISTORY
+        - VIEW_CHANNEL
+        - SEND_MESSAGES
+      show_in_sidebar: true
+      is_mentionable: true
+    - name: Contrib
+      permissions:
+        - MANAGE_CHANNELS
+        - MANAGE_ROLES
+      show_in_sidebar: true
+      is_mentionable: true
+  extra_items:
+    strategy: REMOVE
+
+categories:
+  items:
+    - name: Everyone
+      permissions_overwrites:
+        - role: "@everyone"
+          allow:
+            - VIEW_CHANNEL
+      extra_channels:
+        strategy: SYNC_PERMISSIONS
+    - name: Newcomers
+      permissions_overwrites:
+        - role: Basic
+          allow:
+            - VIEW_CHANNEL
+      extra_channels:
+        strategy: SYNC_PERMISSIONS
+    - name: Pros
+      permissions_overwrites:
+        - role: "@everyone"
+          deny:
+            - VIEW_CHANNEL
+            - CONNECT
+        - role: Contrib
+          allow:
+            - VIEW_CHANNEL
+      extra_channels:
+        strategy: SYNC_PERMISSIONS
+  extra_items:
+    strategy: REMOVE
+
+channels:
+  items:
+    - category: Everyone
+      name: welcome
+      permissions_overwrites:
+        strategy: FROM_CATEGORY
+    - category: Newcomers
+      name: discussion
+      permissions_overwrites:
+        strategy: FROM_CATEGORY
+    - category: Pros
+      name: planing
+      permissions_overwrites:
+        strategy: FROM_CATEGORY
+  extra_items:
+    strategy: REMOVE

--- a/disma/src/api/apply_changes.rs
+++ b/disma/src/api/apply_changes.rs
@@ -96,17 +96,12 @@ impl ApplyChangesUseCase {
 
         for category_change in category_changes {
             match category_change {
-                CategoryChange::Create(awaiting) => commands.push(Arc::from(AddCategory::new(
-                    awaiting,
-                    existing_guild.roles().clone(),
-                ))),
-                CategoryChange::Update(existing, awaiting, _) => {
-                    commands.push(Arc::from(UpdateCategory::new(
-                        existing.clone(),
-                        awaiting.clone(),
-                        existing_guild.roles().clone(),
-                    )))
+                CategoryChange::Create(awaiting) => {
+                    commands.push(Arc::from(AddCategory::new(awaiting)))
                 }
+                CategoryChange::Update(existing, awaiting, _) => commands.push(Arc::from(
+                    UpdateCategory::new(existing.clone(), awaiting.clone()),
+                )),
                 CategoryChange::Delete(existing) => awaiting_guild
                     .categories
                     .extra_items_strategy
@@ -130,19 +125,12 @@ impl ApplyChangesUseCase {
 
         for channel_change in channel_changes {
             match channel_change {
-                ChannelChange::Create(awaiting) => commands.push(Arc::from(AddChannel::new(
-                    awaiting,
-                    existing_guild.roles().clone(),
-                    existing_guild.categories().clone(),
-                ))),
-                ChannelChange::Update(existing, awaiting, _) => {
-                    commands.push(Arc::from(UpdateChannel::new(
-                        existing.clone(),
-                        awaiting.clone(),
-                        existing_guild.roles().clone(),
-                        existing_guild.categories().clone(),
-                    )))
+                ChannelChange::Create(awaiting) => {
+                    commands.push(Arc::from(AddChannel::new(awaiting)))
                 }
+                ChannelChange::Update(existing, awaiting, _) => commands.push(Arc::from(
+                    UpdateChannel::new(existing.clone(), awaiting.clone()),
+                )),
                 ChannelChange::Delete(existing) => awaiting_guild
                     .channels
                     .extra_items_strategy
@@ -150,8 +138,6 @@ impl ApplyChangesUseCase {
                         &existing,
                         &mut commands,
                         awaiting_guild.categories.items.find_by_name(&existing.name),
-                        existing_guild.roles(),
-                        existing_guild.categories(),
                     ),
             }
         }

--- a/disma/src/api/apply_changes.rs
+++ b/disma/src/api/apply_changes.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         events::ChangeEventListenerRef,
     },
-    guild::{AwaitingGuild, GuildCommanderRef, GuildQuerierRef},
+    guild::{AwaitingGuild, ExistingGuild, GuildCommanderRef, GuildQuerierRef},
 };
 
 pub struct ApplyChangesUseCase {
@@ -49,18 +49,23 @@ impl ApplyChangesUseCase {
 
     pub fn execute(&self, guild_id: &str, params: GuildParams) {
         let awaiting_guild: AwaitingGuild = params.into();
+        let mut existing_guild = self.querier.get_guild(guild_id);
 
-        self.apply_role_commands(guild_id, &awaiting_guild);
-        self.apply_category_commands(guild_id, &awaiting_guild);
-        self.apply_channel_commands(guild_id, &awaiting_guild);
+        self.apply_role_commands(&awaiting_guild, &mut existing_guild);
+        self.apply_category_commands(&awaiting_guild, &mut existing_guild);
+        self.apply_channel_commands(&awaiting_guild, &mut existing_guild);
     }
 
-    fn apply_role_commands(&self, guild_id: &str, awaiting_guild: &AwaitingGuild) {
+    fn apply_role_commands(
+        &self,
+        awaiting_guild: &AwaitingGuild,
+        existing_guild: &mut ExistingGuild,
+    ) {
         let mut commands = Vec::<CommandRef>::new();
 
         let role_changes = self
             .role_changes_service
-            .list_changes(&self.querier.get_guild(guild_id), awaiting_guild);
+            .list_changes(existing_guild, awaiting_guild);
 
         for role_change in role_changes {
             match role_change {
@@ -75,16 +80,19 @@ impl ApplyChangesUseCase {
             }
         }
 
-        self.execute_commands(commands);
+        self.execute_commands(commands, existing_guild);
     }
 
-    fn apply_category_commands(&self, guild_id: &str, awaiting_guild: &AwaitingGuild) {
+    fn apply_category_commands(
+        &self,
+        awaiting_guild: &AwaitingGuild,
+        existing_guild: &mut ExistingGuild,
+    ) {
         let mut commands = Vec::<CommandRef>::new();
 
-        let existing_guild = self.querier.get_guild(guild_id);
         let category_changes = self
             .category_changes_service
-            .list_changes(&existing_guild, awaiting_guild);
+            .list_changes(existing_guild, awaiting_guild);
 
         for category_change in category_changes {
             match category_change {
@@ -106,16 +114,19 @@ impl ApplyChangesUseCase {
             }
         }
 
-        self.execute_commands(commands);
+        self.execute_commands(commands, existing_guild);
     }
 
-    fn apply_channel_commands(&self, guild_id: &str, awaiting_guild: &AwaitingGuild) {
+    fn apply_channel_commands(
+        &self,
+        awaiting_guild: &AwaitingGuild,
+        existing_guild: &mut ExistingGuild,
+    ) {
         let mut commands = Vec::<CommandRef>::new();
 
-        let existing_guild = self.querier.get_guild(guild_id);
         let channel_changes = self
             .channel_changes_service
-            .list_changes(&existing_guild, awaiting_guild);
+            .list_changes(existing_guild, awaiting_guild);
 
         for channel_change in channel_changes {
             match channel_change {
@@ -145,12 +156,16 @@ impl ApplyChangesUseCase {
             }
         }
 
-        self.execute_commands(commands);
+        self.execute_commands(commands, existing_guild);
     }
 
-    fn execute_commands(&self, commands: Vec<CommandRef>) {
+    fn execute_commands(&self, commands: Vec<CommandRef>, existing_guild: &mut ExistingGuild) {
         commands.into_iter().for_each(|command| {
-            command.execute(self.commander.as_ref(), self.change_event_listener.as_ref());
+            command.execute(
+                self.commander.as_ref(),
+                self.change_event_listener.as_ref(),
+                existing_guild,
+            );
         });
     }
 }

--- a/disma/src/core/commands/base.rs
+++ b/disma/src/core/commands/base.rs
@@ -1,8 +1,16 @@
 use std::sync::Arc;
 
-use crate::{core::events::ChangeEventListener, guild::GuildCommander};
+use crate::{
+    core::events::ChangeEventListener,
+    guild::{ExistingGuild, GuildCommander},
+};
 
 pub trait Command {
-    fn execute(&self, commander: &dyn GuildCommander, event_listener: &dyn ChangeEventListener);
+    fn execute(
+        &self,
+        commander: &dyn GuildCommander,
+        event_listener: &dyn ChangeEventListener,
+        existing_guild: &mut ExistingGuild,
+    );
 }
 pub type CommandRef = Arc<dyn Command>;

--- a/disma/src/core/commands/role.rs
+++ b/disma/src/core/commands/role.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::events::{Change, ChangeEntity, ChangeEvent, ChangeEventListener},
-    guild::GuildCommander,
+    guild::{ExistingGuild, GuildCommander},
     role::{AwaitingRole, ExistingRole},
 };
 
@@ -21,11 +21,19 @@ impl AddRole {
 }
 
 impl Command for AddRole {
-    fn execute(&self, commander: &dyn GuildCommander, event_listener: &dyn ChangeEventListener) {
+    fn execute(
+        &self,
+        commander: &dyn GuildCommander,
+        event_listener: &dyn ChangeEventListener,
+        existing_guild: &mut ExistingGuild,
+    ) {
         let result = commander.add_role(&self.role);
 
         let event = match result {
-            Ok(_) => ChangeEvent::Success(self.describe()),
+            Ok(role) => {
+                existing_guild.add_or_replace_role(role);
+                ChangeEvent::Success(self.describe())
+            }
             Err(message) => ChangeEvent::Error(self.describe(), message),
         };
 
@@ -52,11 +60,19 @@ impl UpdateRole {
 }
 
 impl Command for UpdateRole {
-    fn execute(&self, commander: &dyn GuildCommander, event_listener: &dyn ChangeEventListener) {
+    fn execute(
+        &self,
+        commander: &dyn GuildCommander,
+        event_listener: &dyn ChangeEventListener,
+        existing_guild: &mut ExistingGuild,
+    ) {
         let result = commander.update_role(&self.existing_role.id, &self.awaiting_role);
 
         let event = match result {
-            Ok(_) => ChangeEvent::Success(self.describe()),
+            Ok(role) => {
+                existing_guild.add_or_replace_role(role);
+                ChangeEvent::Success(self.describe())
+            }
             Err(message) => ChangeEvent::Error(self.describe(), message),
         };
 
@@ -79,10 +95,16 @@ impl DeleteRole {
 }
 
 impl Command for DeleteRole {
-    fn execute(&self, commander: &dyn GuildCommander, event_listener: &dyn ChangeEventListener) {
+    fn execute(
+        &self,
+        commander: &dyn GuildCommander,
+        event_listener: &dyn ChangeEventListener,
+        _existing_guild: &mut ExistingGuild,
+    ) {
         let result = commander.delete_role(&self.role.id);
 
         let event = match result {
+            // TODO remove role (remove only with ID or full existing entity?)
             Ok(()) => ChangeEvent::Success(self.describe()),
             Err(message) => ChangeEvent::Error(self.describe(), message),
         };
@@ -103,7 +125,7 @@ mod tests {
         guild::GuildCommanderMock,
         tests::fixtures::{
             commands::{AddRoleFixture, DeleteRoleFixture, UpdateRoleFixture},
-            existing::ExistingRoleFixture,
+            existing::{ExistingGuildFixture, ExistingRoleFixture},
         },
     };
 
@@ -113,6 +135,7 @@ mod tests {
     fn when_adding_role_should_add_role_with_commander() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let add_command = AddRoleFixture::new().build();
 
         commander
@@ -120,7 +143,7 @@ mod tests {
             .will_return(Ok(ExistingRoleFixture::new().build()));
         event_listener.when_handle(any()).will_return_default();
 
-        add_command.execute(&commander, &event_listener);
+        add_command.execute(&commander, &event_listener, &mut existing_guild);
 
         commander.expect_add_role(eq(&add_command.role));
     }
@@ -129,6 +152,7 @@ mod tests {
     fn given_failing_commander_when_adding_role_should_notify_of_error() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let add_command = AddRoleFixture::new().build();
 
         commander
@@ -136,7 +160,7 @@ mod tests {
             .will_return(Err(AN_ERROR_MESSAGE.to_string()));
         event_listener.when_handle(any()).will_return_default();
 
-        add_command.execute(&commander, &event_listener);
+        add_command.execute(&commander, &event_listener, &mut existing_guild);
 
         event_listener.expect_handle(eq(ChangeEvent::Error(
             Change::Create(ChangeEntity::Role, add_command.role.name.to_string()),
@@ -148,6 +172,7 @@ mod tests {
     fn given_succeeding_commander_when_adding_role_should_notify_of_success() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let add_command = AddRoleFixture::new().build();
 
         commander
@@ -155,7 +180,7 @@ mod tests {
             .will_return(Ok(ExistingRoleFixture::new().build()));
         event_listener.when_handle(any()).will_return_default();
 
-        add_command.execute(&commander, &event_listener);
+        add_command.execute(&commander, &event_listener, &mut existing_guild);
 
         event_listener.expect_handle(eq(ChangeEvent::Success(Change::Create(
             ChangeEntity::Role,
@@ -167,6 +192,7 @@ mod tests {
     fn when_updating_role_should_update_role_with_commander() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let update_command = UpdateRoleFixture::new().build();
 
         commander
@@ -174,7 +200,7 @@ mod tests {
             .will_return(Ok(ExistingRoleFixture::new().build()));
         event_listener.when_handle(any()).will_return_default();
 
-        update_command.execute(&commander, &event_listener);
+        update_command.execute(&commander, &event_listener, &mut existing_guild);
 
         commander.expect_update_role(
             eq(&update_command.existing_role.id),
@@ -186,6 +212,7 @@ mod tests {
     fn given_failing_commander_when_updating_role_should_notify_of_error() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let update_command = UpdateRoleFixture::new().build();
 
         commander
@@ -193,7 +220,7 @@ mod tests {
             .will_return(Err(AN_ERROR_MESSAGE.to_string()));
         event_listener.when_handle(any()).will_return_default();
 
-        update_command.execute(&commander, &event_listener);
+        update_command.execute(&commander, &event_listener, &mut existing_guild);
 
         event_listener.expect_handle(eq(ChangeEvent::Error(
             Change::Update(
@@ -208,6 +235,7 @@ mod tests {
     fn given_succeeding_commander_when_updating_role_should_notify_of_success() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let update_command = UpdateRoleFixture::new().build();
 
         commander
@@ -215,7 +243,7 @@ mod tests {
             .will_return(Ok(ExistingRoleFixture::new().build()));
         event_listener.when_handle(any()).will_return_default();
 
-        update_command.execute(&commander, &event_listener);
+        update_command.execute(&commander, &event_listener, &mut existing_guild);
 
         event_listener.expect_handle(eq(ChangeEvent::Success(Change::Update(
             ChangeEntity::Role,
@@ -227,12 +255,13 @@ mod tests {
     fn when_deleting_role_should_delete_role_with_commander() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let delete_command = DeleteRoleFixture::new().build();
 
         commander.when_delete_role(any()).will_return(Ok(()));
         event_listener.when_handle(any()).will_return_default();
 
-        delete_command.execute(&commander, &event_listener);
+        delete_command.execute(&commander, &event_listener, &mut existing_guild);
 
         commander.expect_delete_role(eq(&delete_command.role.id));
     }
@@ -241,6 +270,7 @@ mod tests {
     fn given_failing_commander_when_deleting_role_should_notify_of_error() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let delete_command = DeleteRoleFixture::new().build();
 
         commander
@@ -248,7 +278,7 @@ mod tests {
             .will_return(Err(AN_ERROR_MESSAGE.to_string()));
         event_listener.when_handle(any()).will_return_default();
 
-        delete_command.execute(&commander, &event_listener);
+        delete_command.execute(&commander, &event_listener, &mut existing_guild);
 
         event_listener.expect_handle(eq(ChangeEvent::Error(
             Change::Delete(ChangeEntity::Role, delete_command.role.name.to_string()),
@@ -260,12 +290,13 @@ mod tests {
     fn given_succeeding_commander_when_deleting_role_should_notify_of_success() {
         let commander = GuildCommanderMock::new();
         let event_listener = ChangeEventListenerMock::new();
+        let mut existing_guild = ExistingGuildFixture::new().build();
         let delete_command = DeleteRoleFixture::new().build();
 
         commander.when_delete_role(any()).will_return(Ok(()));
         event_listener.when_handle(any()).will_return_default();
 
-        delete_command.execute(&commander, &event_listener);
+        delete_command.execute(&commander, &event_listener, &mut existing_guild);
 
         event_listener.expect_handle(eq(ChangeEvent::Success(Change::Delete(
             ChangeEntity::Role,

--- a/disma/src/core/commands/role.rs
+++ b/disma/src/core/commands/role.rs
@@ -99,13 +99,15 @@ impl Command for DeleteRole {
         &self,
         commander: &dyn GuildCommander,
         event_listener: &dyn ChangeEventListener,
-        _existing_guild: &mut ExistingGuild,
+        existing_guild: &mut ExistingGuild,
     ) {
         let result = commander.delete_role(&self.role.id);
 
         let event = match result {
-            // TODO remove role (remove only with ID or full existing entity?)
-            Ok(()) => ChangeEvent::Success(self.describe()),
+            Ok(()) => {
+                existing_guild.remove_role(self.role.clone());
+                ChangeEvent::Success(self.describe())
+            }
             Err(message) => ChangeEvent::Error(self.describe(), message),
         };
 

--- a/disma/src/domain/category/base.rs
+++ b/disma/src/domain/category/base.rs
@@ -98,4 +98,8 @@ impl CategoriesList<ExistingCategory> {
         self.categories_by_name
             .insert(category.name().to_string(), category);
     }
+
+    pub fn remove(&mut self, category: ExistingCategory) {
+        self.categories_by_name.remove(category.name());
+    }
 }

--- a/disma/src/domain/channel/base.rs
+++ b/disma/src/domain/channel/base.rs
@@ -153,6 +153,11 @@ impl ChannelsList<ExistingChannel> {
         self.channels_by_name
             .insert(channel.unique_name().to_string(), channel);
     }
+
+    pub fn remove(&mut self, channel: ExistingChannel) {
+        self.channels_by_name
+            .remove(&channel.unique_name().to_string());
+    }
 }
 
 #[cfg(test)]

--- a/disma/src/domain/channel/extra.rs
+++ b/disma/src/domain/channel/extra.rs
@@ -2,13 +2,12 @@ use core::fmt::Debug;
 use std::sync::Arc;
 
 use crate::{
-    category::{AwaitingCategory, CategoriesList, ExistingCategory},
+    category::AwaitingCategory,
     channel::{AwaitingChannel, Channel, ExistingChannel},
     core::commands::{
         channel::{DeleteChannel, UpdateChannel},
         CommandRef,
     },
-    role::{ExistingRole, RolesList},
 };
 
 pub trait ExtraChannelsStrategy {
@@ -18,8 +17,6 @@ pub trait ExtraChannelsStrategy {
         extra_channel: &ExistingChannel,
         commands: &mut Vec<CommandRef>,
         awaiting_category: Option<&AwaitingCategory>,
-        roles: &RolesList<ExistingRole>,
-        categories: &CategoriesList<ExistingCategory>,
     );
 }
 
@@ -48,8 +45,6 @@ impl ExtraChannelsStrategy for RemoveExtraChannels {
         extra_channel: &ExistingChannel,
         commands: &mut Vec<CommandRef>,
         _awaiting_category: Option<&AwaitingCategory>,
-        _roles: &RolesList<ExistingRole>,
-        _categories: &CategoriesList<ExistingCategory>,
     ) {
         let command = DeleteChannel::new(extra_channel.clone());
         commands.push(Arc::from(command));
@@ -68,8 +63,6 @@ impl ExtraChannelsStrategy for KeepExtraChannels {
         _extra_channel: &ExistingChannel,
         _commands: &mut Vec<CommandRef>,
         _awaiting_category: Option<&AwaitingCategory>,
-        _roles: &RolesList<ExistingRole>,
-        _categories: &CategoriesList<ExistingCategory>,
     ) {
     }
 }
@@ -86,8 +79,6 @@ impl ExtraChannelsStrategy for SyncExtraChannelsPermissions {
         extra_channel: &ExistingChannel,
         commands: &mut Vec<CommandRef>,
         awaiting_category: Option<&AwaitingCategory>,
-        roles: &RolesList<ExistingRole>,
-        categories: &CategoriesList<ExistingCategory>,
     ) {
         if let Some(category) = awaiting_category {
             let awaiting_channel = AwaitingChannel {
@@ -98,12 +89,7 @@ impl ExtraChannelsStrategy for SyncExtraChannelsPermissions {
                 overwrites: category.overwrites.clone(),
             };
 
-            let command = UpdateChannel::new(
-                extra_channel.clone(),
-                awaiting_channel,
-                roles.clone(),
-                categories.clone(),
-            );
+            let command = UpdateChannel::new(extra_channel.clone(), awaiting_channel);
             commands.push(Arc::from(command));
         } else {
             panic!("Category cannot be empty for overriding permissions overwrites of extra channel {}", extra_channel.name());

--- a/disma/src/domain/guild/query.rs
+++ b/disma/src/domain/guild/query.rs
@@ -41,11 +41,11 @@ impl ExistingGuild {
     }
 
     pub fn add_or_replace_role(&mut self, role: ExistingRole) {
-        self.roles.add_or_replace(role)
+        self.roles.add_or_replace(role);
     }
 
-    pub fn remove_role(&mut self, _role: ExistingRole) {
-        todo!()
+    pub fn remove_role(&mut self, role: ExistingRole) {
+        self.roles.remove(role);
     }
 
     pub fn categories(&self) -> &CategoriesList<ExistingCategory> {
@@ -53,7 +53,11 @@ impl ExistingGuild {
     }
 
     pub fn add_or_replace_category(&mut self, category: ExistingCategory) {
-        self.categories.add_or_replace(category)
+        self.categories.add_or_replace(category);
+    }
+
+    pub fn remove_category(&mut self, category: ExistingCategory) {
+        self.categories.remove(category);
     }
 
     pub fn channels(&self) -> &ChannelsList<ExistingChannel> {
@@ -61,7 +65,11 @@ impl ExistingGuild {
     }
 
     pub fn add_or_replace_channel(&mut self, channel: ExistingChannel) {
-        self.channels.add_or_replace(channel)
+        self.channels.add_or_replace(channel);
+    }
+
+    pub fn remove_channel(&mut self, channel: ExistingChannel) {
+        self.channels.remove(channel);
     }
 }
 

--- a/disma/src/domain/guild/query.rs
+++ b/disma/src/domain/guild/query.rs
@@ -53,9 +53,6 @@ impl ExistingGuild {
     }
 
     pub fn add_or_replace_category(&mut self, category: ExistingCategory) {
-        // TODO check for existing roles??
-        // Or reput complex objects instead of references?
-
         self.categories.add_or_replace(category)
     }
 

--- a/disma/src/domain/role/base.rs
+++ b/disma/src/domain/role/base.rs
@@ -91,4 +91,8 @@ impl RolesList<ExistingRole> {
     pub fn add_or_replace(&mut self, role: ExistingRole) {
         self.roles_by_name.insert(role.name().to_string(), role);
     }
+
+    pub fn remove(&mut self, role: ExistingRole) {
+        self.roles_by_name.remove(role.name());
+    }
 }

--- a/disma/src/tests/fixtures/commands/category.rs
+++ b/disma/src/tests/fixtures/commands/category.rs
@@ -1,6 +1,5 @@
 use crate::{
     core::commands::category::{AddCategory, DeleteCategory, UpdateCategory},
-    role::RolesList,
     tests::fixtures::{awaiting::AwaitingCategoryFixture, existing::ExistingCategoryFixture},
 };
 
@@ -12,7 +11,7 @@ impl AddCategoryFixture {
     }
 
     pub fn build(self) -> AddCategory {
-        AddCategory::new(AwaitingCategoryFixture::new().build(), RolesList::new())
+        AddCategory::new(AwaitingCategoryFixture::new().build())
     }
 }
 
@@ -27,7 +26,6 @@ impl UpdateCategoryFixture {
         UpdateCategory::new(
             ExistingCategoryFixture::new().build(),
             AwaitingCategoryFixture::new().build(),
-            RolesList::new(),
         )
     }
 }

--- a/disma/src/tests/fixtures/commands/channel.rs
+++ b/disma/src/tests/fixtures/commands/channel.rs
@@ -1,7 +1,5 @@
 use crate::{
-    category::CategoriesList,
     core::commands::channel::{AddChannel, DeleteChannel, UpdateChannel},
-    role::RolesList,
     tests::fixtures::{awaiting::AwaitingChannelFixture, existing::ExistingChannelFixture},
 };
 
@@ -13,11 +11,7 @@ impl AddChannelFixture {
     }
 
     pub fn build(self) -> AddChannel {
-        AddChannel::new(
-            AwaitingChannelFixture::new().build(),
-            RolesList::new(),
-            CategoriesList::new(),
-        )
+        AddChannel::new(AwaitingChannelFixture::new().build())
     }
 }
 
@@ -32,8 +26,6 @@ impl UpdateChannelFixture {
         UpdateChannel::new(
             ExistingChannelFixture::new().build(),
             AwaitingChannelFixture::new().build(),
-            RolesList::new(),
-            CategoriesList::new(),
         )
     }
 }


### PR DESCRIPTION
Relates to #105, #117
Fixes #106
Fixes #37
Fixes #85

### TODO

- [x] Remove entities (by id or entire entity?)
- [x] Check for removing commands dependencies on existing lists (since the list is sent on execution)